### PR TITLE
Remove NuGet configurations from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,25 +11,3 @@ updates:
       all-packages:
         patterns:
         - "*"
-  - package-ecosystem: "nuget"
-    directory: "/tests/ADDSMock.Tests/Data/ComplexSolution"
-    schedule:
-      interval: "monthly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      all-packages:
-        patterns:
-        - "*"
-  - package-ecosystem: "nuget"
-    directory: "/tests/ADDSMock.Tests/Data/DemoSolution"
-    schedule:
-      interval: "monthly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      all-packages:
-        patterns:
-        - "*"


### PR DESCRIPTION
Remove NuGet configurations from dependabot.yml

Updated the `dependabot.yml` file to eliminate configurations for the NuGet package ecosystem in the `/tests/ADDSMock.Tests/Data/ComplexSolution` and `/tests/ADDSMock.Tests/Data/DemoSolution` directories. This includes the removal of schedule intervals, ignore rules, and update types for handling major version updates for dependencies.