### PR TITLE
Removed service configuration path from mock-configuration.json

### DIFF
--- a/src/ADDSMock/ADDSMock.csproj
+++ b/src/ADDSMock/ADDSMock.csproj
@@ -20,11 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Domain\Traffic\" />
-    <Folder Include="Extensions\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Update="mock-configuration.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -34,6 +29,10 @@
     <Content Update="Dockerfile">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(SolutionDir)service-configuration\**" CopyToOutputDirectory="Always" LinkBase="service-configuration"/>
   </ItemGroup>
 
   <!--Console/Web and Interactive Mode-->

--- a/src/ADDSMock/Domain/Configuration/MockConfiguration.cs
+++ b/src/ADDSMock/Domain/Configuration/MockConfiguration.cs
@@ -9,16 +9,14 @@ namespace ADDSMock.Domain.Configuration
 {
     public class MockConfiguration
     {
-        public MockConfiguration(string configurationPath, string overrideConfigurationPath, int port, bool useSsl, bool useHttp2)
+        public MockConfiguration(string overrideConfigurationPath, int port, bool useSsl, bool useHttp2)
         {
-            ConfigurationPath = configurationPath;
             OverrideConfigurationPath = overrideConfigurationPath;
             Port = port;
             UseSsl = useSsl;
             UseHttp2 = useHttp2;
         }
 
-        public string ConfigurationPath { get; set; }
         public string OverrideConfigurationPath { get; set; }
 
         public int Port { get; }
@@ -33,7 +31,6 @@ namespace ADDSMock.Domain.Configuration
             var solutionDirectoryPath = fileSystem.Path.Combine(currentDirectoryPath, @"..\..\");
             var configurationDirectoryPath = fileSystem.Path.GetFullPath(solutionDirectoryPath);
 
-            var serviceConfigurationPath = fileSystem.Path.Combine(configurationDirectoryPath, "service-configuration");
             var overrideConfigurationPath = fileSystem.Path.Combine(configurationDirectoryPath, "override-configuration");
 
             var configurationFilePath = fileSystem.Path.Combine(configurationPath, path);
@@ -50,7 +47,6 @@ namespace ADDSMock.Domain.Configuration
                 // This code will only run in Debug mode
 #if DEBUG
                 
-                    configuration.ConfigurationPath = serviceConfigurationPath;
                     configuration.OverrideConfigurationPath = overrideConfigurationPath;
                 
 #endif

--- a/src/ADDSMock/Domain/Services/Runtime/MappingService.cs
+++ b/src/ADDSMock/Domain/Services/Runtime/MappingService.cs
@@ -7,6 +7,7 @@ using ADDSMock.Domain.Events;
 using ADDSMock.Domain.Mappings;
 using CSScriptLib;
 using LightResults;
+using Microsoft.Extensions.Configuration;
 using ReactiveUI;
 using Serilog;
 using WireMock.Matchers.Request;
@@ -90,9 +91,12 @@ namespace ADDSMock.Domain.Services.Runtime
         {
             _services = _environmentService.Services.Configurations.Select(x => new MockService(x.Prefix, x.Name)).ToList();
 
+            var configurationPathRoot = _fileSystem.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+            var configurationPath = _fileSystem.Path.Combine(configurationPathRoot, "service-configuration");
+
             foreach (var service in _services)
             {
-                var servicePath = _fileSystem.Path.Combine(_environmentService.Mock.ConfigurationPath, service.ServicePrefix);
+                var servicePath = _fileSystem.Path.Combine(configurationPath, service.ServicePrefix);
                 var overrideServicePath = _fileSystem.Path.Combine(_environmentService.Mock.OverrideConfigurationPath, service.ServicePrefix);
 
                 var serviceConfigPath = _fileSystem.Path.Combine(servicePath, "configuration.json");
@@ -201,11 +205,6 @@ namespace ADDSMock.Domain.Services.Runtime
             {
                 foreach (var fragment in service.Fragments)
                 {
-                    if (service.ServicePrefix == "scs")
-                    {
-                        var zz = 42;
-                    }
-
                     var beforeConfigurationIds = wireMockService.WireMockServer!.MappingModels.Select(x => x.Guid).ToList();
 
                     try

--- a/src/ADDSMock/mock-configuration.json
+++ b/src/ADDSMock/mock-configuration.json
@@ -1,5 +1,4 @@
 ﻿{
-  "ConfigurationPath": "C:\\a\\2\\s\\mock\\repo\\service-configuration",
   "OverrideConfigurationPath": "C:\\Dev\\UKHO\\UKHO.Mocks.ADDS\\override-configuration",
   "Port": 8080,
   "UseSsl": false,


### PR DESCRIPTION
ADDSMock now copies all configuration from the service-configuration location to the build output directory and references it from there. The override path is still maintained in the mock-configuration.json file.