### PR TITLE
215959- Additional SCS Mock Error Codes

### DIFF
--- a/src/ADDSMock/service-configuration/scs/api-responses.cs
+++ b/src/ADDSMock/service-configuration/scs/api-responses.cs
@@ -36,6 +36,19 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         );
 
     server
+    .Given(
+        Request.Create()
+            .WithUrl(new RegexMatcher(urlPattern))
+            .WithHeader("_X-Correlation-ID", "304-notmodified-guid-scs")
+            .UsingGet()
+    )
+    .RespondWith(
+        Response.Create()
+            .WithStatusCode(304)            
+            .WithHeader("Last-Modified", "2025-01-01T00:00:00Z")            
+    );
+
+    server
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
@@ -47,7 +60,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
                 .WithStatusCode(400)
                 .WithHeader("Content-Type", "application/json")
                 .WithBody("Bad request.")
-        );
+        );   
 
     server
         .Given(

--- a/src/ADDSMock/service-configuration/scs/api-responses.cs
+++ b/src/ADDSMock/service-configuration/scs/api-responses.cs
@@ -51,7 +51,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader("If-Modified-Since", "3000-01-01T00:00:00Z")
+                .WithHeader("_X-Correlation-ID", "500-internalserver-guid")
                 .UsingGet()
         )
         .RespondWith(
@@ -60,4 +60,60 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
                 .WithHeader("Content-Type", "application/json")
                 .WithBody("Internal server error.")
         );
+
+    server
+        .Given(
+            Request.Create()
+                .WithUrl(new RegexMatcher(urlPattern))
+                .WithHeader("_X-Correlation-ID", "401-unauthorised-guid")
+                .UsingGet()
+        )
+        .RespondWith(
+            Response.Create()
+                .WithStatusCode(401)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("Unauthorised.")
+        );
+
+    server
+        .Given(
+            Request.Create()
+                .WithUrl(new RegexMatcher(urlPattern))
+                .WithHeader("_X-Correlation-ID", "403-forbidden-guid")
+                .UsingGet()
+        )
+        .RespondWith(
+            Response.Create()
+                .WithStatusCode(403)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("Forbidden.")
+        );
+
+    server
+        .Given(
+            Request.Create()
+                .WithUrl(new RegexMatcher(urlPattern))
+                .WithHeader("_X-Correlation-ID", "404-notfound-guid")
+                .UsingGet()
+        )
+        .RespondWith(
+            Response.Create()
+                .WithStatusCode(404)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("Not found.")
+        );
+
+    server
+       .Given(
+           Request.Create()
+               .WithUrl(new RegexMatcher(urlPattern))
+               .WithHeader("_X-Correlation-ID", "415-unsupportedmediatype-guid")
+               .UsingGet()
+       )
+       .RespondWith(
+           Response.Create()
+               .WithStatusCode(415)
+               .WithHeader("Content-Type", "application/json")
+               .WithBody("Unsupported Media Type.")
+       );
 }

--- a/src/ADDSMock/service-configuration/scs/api-responses.cs
+++ b/src/ADDSMock/service-configuration/scs/api-responses.cs
@@ -18,6 +18,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
+                .WithHeader("Last-Modified", "2025-01-01T00:00:00Z")
                 .WithBodyFromFile(mockService.Files.FirstOrDefault()?.Path)
         );
 
@@ -31,6 +32,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .RespondWith(
             Response.Create()
                 .WithStatusCode(304)
+                .WithHeader("Last-Modified", "2025-01-01T00:00:00Z")
         );
 
     server
@@ -51,7 +53,21 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader("_X-Correlation-ID", "500-internalserver-guid")
+                .WithHeader("_X-Correlation-ID", "400-badrequest-guid-scs")
+                .UsingGet()
+        )
+        .RespondWith(
+            Response.Create()
+                .WithStatusCode(400)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("Bad request.")
+        );
+
+    server
+        .Given(
+            Request.Create()
+                .WithUrl(new RegexMatcher(urlPattern))
+                .WithHeader("_X-Correlation-ID", "500-internalserver-guid-scs")
                 .UsingGet()
         )
         .RespondWith(
@@ -65,7 +81,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader("_X-Correlation-ID", "401-unauthorised-guid")
+                .WithHeader("_X-Correlation-ID", "401-unauthorised-guid-scs")
                 .UsingGet()
         )
         .RespondWith(
@@ -79,7 +95,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader("_X-Correlation-ID", "403-forbidden-guid")
+                .WithHeader("_X-Correlation-ID", "403-forbidden-guid-scs")
                 .UsingGet()
         )
         .RespondWith(
@@ -93,7 +109,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader("_X-Correlation-ID", "404-notfound-guid")
+                .WithHeader("_X-Correlation-ID", "404-notfound-guid-scs")
                 .UsingGet()
         )
         .RespondWith(
@@ -107,7 +123,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
        .Given(
            Request.Create()
                .WithUrl(new RegexMatcher(urlPattern))
-               .WithHeader("_X-Correlation-ID", "415-unsupportedmediatype-guid")
+               .WithHeader("_X-Correlation-ID", "415-unsupportedmediatype-guid-scs")
                .UsingGet()
        )
        .RespondWith(

--- a/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
+++ b/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
@@ -75,7 +75,11 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
                 .WithStatusCode(500)
                 .WithHeader("Content-Type", "application/json")
                 .WithHeader("_X-Correlation-ID", "500-internalserver-guid-scs-basic-catalogue")
-                .WithBody("Internal server error.")
+                .WithBodyAsJson(new
+                {
+                    correlationId = "500-internalserver-guid-scs-basic-catalogue",
+                    details = "Internal Server Error"
+                })
         );
 
     server
@@ -90,7 +94,6 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
                 .WithStatusCode(401)
                 .WithHeader("Content-Type", "application/json")
                 .WithHeader("_X-Correlation-ID", "401-unauthorised-guid-scs-basic-catalogue")
-                .WithBody("Unauthorised.")
         );
 
     server
@@ -105,7 +108,6 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
                 .WithStatusCode(403)
                 .WithHeader("Content-Type", "application/json")
                 .WithHeader("_X-Correlation-ID", "403-forbidden-guid-scs-basic-catalogue")
-                .WithBody("Forbidden.")
         );
 
     server
@@ -120,21 +122,30 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
                 .WithStatusCode(404)
                 .WithHeader("Content-Type", "application/json")
                 .WithHeader("_X-Correlation-ID", "404-notfound-guid-scs-basic-catalogue")
-                .WithBody("Not found.")
+                .WithBodyAsJson(new
+                {
+                    correlationId = "404-notfound-guid-scs-basic-catalogue",
+                    details = "Not Found"
+                })
         );
 
     server
-       .Given(
-           Request.Create()
-               .WithUrl(new RegexMatcher(urlPattern))
-               .WithHeader("_X-Correlation-ID", "415-unsupportedmediatype-guid-scs-basic-catalogue")
-               .UsingGet()
-       )
-       .RespondWith(
-           Response.Create()
-               .WithStatusCode(415)
-               .WithHeader("Content-Type", "application/json")
-               .WithHeader("_X-Correlation-ID", "415-unsupportedmediatype-guid-scs-basic-catalogue")
-               .WithBody("Unsupported Media Type.")
-       );
+        .Given(
+            Request.Create()
+                .WithUrl(new RegexMatcher(urlPattern))
+                .WithHeader("_X-Correlation-ID", "415-unsupportedmediatype-guid-scs-basic-catalogue")
+                .UsingGet()
+        )
+        .RespondWith(
+            Response.Create()
+                .WithStatusCode(415)
+                .WithHeader("Content-Type", "application/json")
+                .WithBodyAsJson(new
+                {
+                    type = "https://example.com",
+                    title = "Unsupported Media Type",
+                    status = 415,
+                    traceId = "00-012-0123-01"
+                })
+        );
 }

--- a/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
+++ b/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
@@ -18,22 +18,22 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Response.Create()
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
-                .WithHeader("Last-Modified", "2025-01-01T00:00:00Z")
+                .WithHeader("Last-Modified", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))
                 .WithBodyFromFile(mockService.Files.FirstOrDefault()?.Path)
         );
 
-    server
-        .Given(
-            Request.Create()
-                .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader("If-Modified-Since", "2025-01-01T00:00:00Z")
-                .UsingGet()
-        )
-        .RespondWith(
-            Response.Create()
-                .WithStatusCode(304)
-                .WithHeader("Last-Modified", "2025-01-01T00:00:00Z")
-        );
+    //server
+    //    .Given(
+    //        Request.Create()
+    //            .WithUrl(new RegexMatcher(urlPattern))
+    //            .WithHeader("If-Modified-Since", "2025-01-01T00:00:00Z")
+    //            .UsingGet()
+    //    )
+    //    .RespondWith(
+    //        Response.Create()
+    //            .WithStatusCode(304)
+    //            .WithHeader("Last-Modified", "2025-01-01T00:00:00Z")
+    //    );
 
     server
     .Given(
@@ -44,15 +44,15 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
     )
     .RespondWith(
         Response.Create()
-            .WithStatusCode(304)            
-            .WithHeader("Last-Modified", "2025-01-01T00:00:00Z")            
+            .WithStatusCode(304)
+            .WithHeader("Last-Modified", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))
     );
 
     server
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader("If-Modified-Since", "20221027")
+                //.WithHeader("If-Modified-Since", "20221027")
                 .UsingGet()
         )
         .RespondWith(

--- a/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
+++ b/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
@@ -24,18 +24,18 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         );
 
     server
-    .Given(
-        Request.Create()
-            .WithUrl(new RegexMatcher(urlPattern))
-            .WithHeader("_X-Correlation-ID", "304-notmodified-guid-scs-basic-catalogue")
-            .UsingGet()
-    )
-    .RespondWith(
-        Response.Create()
-            .WithStatusCode(304)
-            .WithHeader("Last-Modified", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))
-            .WithHeader("_X-Correlation-ID", "304-notmodified-guid-scs-basic-catalogue")
-    );
+        .Given(
+            Request.Create()
+                .WithUrl(new RegexMatcher(urlPattern))
+                .WithHeader("_X-Correlation-ID", "304-notmodified-guid-scs-basic-catalogue")
+                .UsingGet()
+        )
+        .RespondWith(
+            Response.Create()
+                .WithStatusCode(304)
+                .WithHeader("Last-Modified", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))
+                .WithHeader("_X-Correlation-ID", "304-notmodified-guid-scs-basic-catalogue")
+        );
 
     server
         .Given(

--- a/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
+++ b/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
@@ -19,7 +19,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
                 .WithHeader("Last-Modified", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))
-                .WithHeader("_X-Correlation-ID", "200-ok-guid-scs")
+                .WithHeader("_X-Correlation-ID", "200-ok-guid-scs-basic-catalogue")
                 .WithBodyFromFile(mockService.Files.FirstOrDefault()?.Path)
         );
 
@@ -27,28 +27,28 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
     .Given(
         Request.Create()
             .WithUrl(new RegexMatcher(urlPattern))
-            .WithHeader("_X-Correlation-ID", "304-notmodified-guid-scs")
+            .WithHeader("_X-Correlation-ID", "304-notmodified-guid-scs-basic-catalogue")
             .UsingGet()
     )
     .RespondWith(
         Response.Create()
             .WithStatusCode(304)
             .WithHeader("Last-Modified", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))
-            .WithHeader("_X-Correlation-ID", "304-notmodified-guid-scs")
+            .WithHeader("_X-Correlation-ID", "304-notmodified-guid-scs-basic-catalogue")
     );
 
     server
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader("_X-Correlation-ID", "400-badrequest-guid-scs")
+                .WithHeader("_X-Correlation-ID", "400-badrequest-guid-scs-basic-catalogue")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(400)
                 .WithHeader("Content-Type", "application/json")
-                .WithHeader("_X-Correlation-ID", "400-badrequest-guid-scs")
+                .WithHeader("_X-Correlation-ID", "400-badrequest-guid-scs-basic-catalogue")
                 .WithBody("Bad request.")
         );
 
@@ -56,14 +56,14 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader("_X-Correlation-ID", "500-internalserver-guid-scs")
+                .WithHeader("_X-Correlation-ID", "500-internalserver-guid-scs-basic-catalogue")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(500)
                 .WithHeader("Content-Type", "application/json")
-                .WithHeader("_X-Correlation-ID", "500-internalserver-guid-scs")
+                .WithHeader("_X-Correlation-ID", "500-internalserver-guid-scs-basic-catalogue")
                 .WithBody("Internal server error.")
         );
 
@@ -71,14 +71,14 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader("_X-Correlation-ID", "401-unauthorised-guid-scs")
+                .WithHeader("_X-Correlation-ID", "401-unauthorised-guid-scs-basic-catalogue")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(401)
                 .WithHeader("Content-Type", "application/json")
-                .WithHeader("_X-Correlation-ID", "401-unauthorised-guid-scs")
+                .WithHeader("_X-Correlation-ID", "401-unauthorised-guid-scs-basic-catalogue")
                 .WithBody("Unauthorised.")
         );
 
@@ -86,14 +86,14 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader("_X-Correlation-ID", "403-forbidden-guid-scs")
+                .WithHeader("_X-Correlation-ID", "403-forbidden-guid-scs-basic-catalogue")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(403)
                 .WithHeader("Content-Type", "application/json")
-                .WithHeader("_X-Correlation-ID", "403-forbidden-guid-scs")
+                .WithHeader("_X-Correlation-ID", "403-forbidden-guid-scs-basic-catalogue")
                 .WithBody("Forbidden.")
         );
 
@@ -101,14 +101,14 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader("_X-Correlation-ID", "404-notfound-guid-scs")
+                .WithHeader("_X-Correlation-ID", "404-notfound-guid-scs-basic-catalogue")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(404)
                 .WithHeader("Content-Type", "application/json")
-                .WithHeader("_X-Correlation-ID", "404-notfound-guid-scs")
+                .WithHeader("_X-Correlation-ID", "404-notfound-guid-scs-basic-catalogue")
                 .WithBody("Not found.")
         );
 
@@ -116,14 +116,14 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
        .Given(
            Request.Create()
                .WithUrl(new RegexMatcher(urlPattern))
-               .WithHeader("_X-Correlation-ID", "415-unsupportedmediatype-guid-scs")
+               .WithHeader("_X-Correlation-ID", "415-unsupportedmediatype-guid-scs-basic-catalogue")
                .UsingGet()
        )
        .RespondWith(
            Response.Create()
                .WithStatusCode(415)
                .WithHeader("Content-Type", "application/json")
-               .WithHeader("_X-Correlation-ID", "415-unsupportedmediatype-guid-scs")
+               .WithHeader("_X-Correlation-ID", "415-unsupportedmediatype-guid-scs-basic-catalogue")
                .WithBody("Unsupported Media Type.")
        );
 }

--- a/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
+++ b/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
@@ -19,21 +19,9 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
                 .WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
                 .WithHeader("Last-Modified", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))
+                .WithHeader("_X-Correlation-ID", "200-ok-guid-scs")
                 .WithBodyFromFile(mockService.Files.FirstOrDefault()?.Path)
         );
-
-    //server
-    //    .Given(
-    //        Request.Create()
-    //            .WithUrl(new RegexMatcher(urlPattern))
-    //            .WithHeader("If-Modified-Since", "2025-01-01T00:00:00Z")
-    //            .UsingGet()
-    //    )
-    //    .RespondWith(
-    //        Response.Create()
-    //            .WithStatusCode(304)
-    //            .WithHeader("Last-Modified", "2025-01-01T00:00:00Z")
-    //    );
 
     server
     .Given(
@@ -46,21 +34,8 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         Response.Create()
             .WithStatusCode(304)
             .WithHeader("Last-Modified", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))
+            .WithHeader("_X-Correlation-ID", "304-notmodified-guid-scs")
     );
-
-    server
-        .Given(
-            Request.Create()
-                .WithUrl(new RegexMatcher(urlPattern))
-                //.WithHeader("If-Modified-Since", "20221027")
-                .UsingGet()
-        )
-        .RespondWith(
-            Response.Create()
-                .WithStatusCode(400)
-                .WithHeader("Content-Type", "application/json")
-                .WithBody("Bad request.")
-        );   
 
     server
         .Given(
@@ -73,6 +48,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Response.Create()
                 .WithStatusCode(400)
                 .WithHeader("Content-Type", "application/json")
+                .WithHeader("_X-Correlation-ID", "400-badrequest-guid-scs")
                 .WithBody("Bad request.")
         );
 
@@ -87,6 +63,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Response.Create()
                 .WithStatusCode(500)
                 .WithHeader("Content-Type", "application/json")
+                .WithHeader("_X-Correlation-ID", "500-internalserver-guid-scs")
                 .WithBody("Internal server error.")
         );
 
@@ -101,6 +78,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Response.Create()
                 .WithStatusCode(401)
                 .WithHeader("Content-Type", "application/json")
+                .WithHeader("_X-Correlation-ID", "401-unauthorised-guid-scs")
                 .WithBody("Unauthorised.")
         );
 
@@ -115,6 +93,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Response.Create()
                 .WithStatusCode(403)
                 .WithHeader("Content-Type", "application/json")
+                .WithHeader("_X-Correlation-ID", "403-forbidden-guid-scs")
                 .WithBody("Forbidden.")
         );
 
@@ -129,6 +108,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Response.Create()
                 .WithStatusCode(404)
                 .WithHeader("Content-Type", "application/json")
+                .WithHeader("_X-Correlation-ID", "404-notfound-guid-scs")
                 .WithBody("Not found.")
         );
 
@@ -143,6 +123,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
            Response.Create()
                .WithStatusCode(415)
                .WithHeader("Content-Type", "application/json")
+               .WithHeader("_X-Correlation-ID", "415-unsupportedmediatype-guid-scs")
                .WithBody("Unsupported Media Type.")
        );
 }

--- a/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
+++ b/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
@@ -49,7 +49,18 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
                 .WithStatusCode(400)
                 .WithHeader("Content-Type", "application/json")
                 .WithHeader("_X-Correlation-ID", "400-badrequest-guid-scs-basic-catalogue")
-                .WithBody("Bad request.")
+                .WithBodyAsJson(new
+                {
+                    correlationId = "400-badrequest-guid-scs-basic-catalogue",
+                    errors = new[]
+                    {
+                        new
+                        {
+                            source = "Basic Catalogue",
+                            description = "Provided date format is not valid."
+                        }
+                    }
+                })
         );
 
     server


### PR DESCRIPTION
This PR consists of  additional SCS Mock error codes.

1. 400 Bad Request
2. 500 Internal server error.
3. 401 Unauthorized. 
4. 403 Forbidden.
5. 404 Not found.
6. 415 Unsupported media type.