### PR TITLE
217955 :  Rename Corr ID in Header and Logs

### DIFF
--- a/src/ADDSMock/Constants/MockConstants.cs
+++ b/src/ADDSMock/Constants/MockConstants.cs
@@ -17,7 +17,7 @@
         public const string ForbiddenCorrelationId = "403-forbidden-guid-";
         public const string FileNotFoundCorrelationId = "404-filenotfound-guid-";
         public const string GoneCorrelationId = "410-gone-guid-";
-        public const string RangeNotSatisfiableCorrelationId = "416-rangenotsatisfiable-guid-"; // Fixed typo
+        public const string RangeNotSatisfiableCorrelationId = "416-rangenotsatisfiable-guid-";
         public const string TooManyRequestsCorrelationId = "429-toomanyrequests-guid-";
         public const string TemporaryRedirectCorrelationId = "307-temporaryredirect-guid-";
 

--- a/src/ADDSMock/Constants/MockConstants.cs
+++ b/src/ADDSMock/Constants/MockConstants.cs
@@ -18,6 +18,7 @@
         public const string FileNotFoundCorrelationId = "404-filenotfound-guid-";
         public const string GoneCorrelationId = "410-gone-guid-";
         public const string RangeNotSatisfiableCorrelationId = "416-rangenotsatisfiable-guid-";
+        public const string UnsupportedMediaTypeCorrelationId = "415-unsupportedmediatype-guid-";
         public const string TooManyRequestsCorrelationId = "429-toomanyrequests-guid-";
         public const string TemporaryRedirectCorrelationId = "307-temporaryredirect-guid-";
 

--- a/src/ADDSMock/ResponseGenerator/FSSResponseGenerator.cs
+++ b/src/ADDSMock/ResponseGenerator/FSSResponseGenerator.cs
@@ -9,13 +9,11 @@ namespace ADDSMock.ResponseGenerator
 {
     public static class FSSResponseGenerator
     {
-        private static readonly string _templatePath = @"..\ADDSMock\service-configuration\fss\files\search-product.json";
-
-        public static async Task<ResponseMessage> ProvideSearchFilterResponse(IRequestMessage requestMessage)
+        public static async Task<ResponseMessage> ProvideSearchFilterResponse(IRequestMessage requestMessage, string templatePath)
         {
             try
             {
-                var jsonTemplate = JsonNode.Parse(await File.ReadAllTextAsync(_templatePath))?.AsObject();                
+                var jsonTemplate = JsonNode.Parse(await File.ReadAllTextAsync(templatePath))?.AsObject();
 
                 var filter = requestMessage.Query["$filter"].FirstOrDefault();
                 if (string.IsNullOrEmpty(filter))
@@ -138,11 +136,9 @@ namespace ADDSMock.ResponseGenerator
 
             return new JsonObject
             {
-                ["self"] = encodedFilterUrl,
-                ["first"] = encodedFilterUrl,
-                ["previous"] = encodedFilterUrl,
-                ["next"] = encodedFilterUrl,
-                ["last"] = encodedFilterUrl
+                ["self"] = new JsonObject { ["href"] = encodedFilterUrl },
+                ["first"] = new JsonObject { ["href"] = encodedFilterUrl },
+                ["last"] = new JsonObject { ["href"] = encodedFilterUrl }
             };
         }
     }

--- a/src/ADDSMock/service-configuration/fss/add-file.cs
+++ b/src/ADDSMock/service-configuration/fss/add-file.cs
@@ -30,7 +30,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Response.Create()
                 .WithStatusCode(201)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.CreatedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.CreatedCorrelationId}{endPoint}")
         );
 
     // 400 Bad Request Response
@@ -38,17 +38,17 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithPath(urlPattern)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{endPoint}")
                 .UsingPost()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(400)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{endPoint}")
                 .WithBodyAsJson(new
                 {
-                    correlationId = $"{MockConstants.BadRequestCorrelationId}{EndPoint}",
+                    correlationId = $"{MockConstants.BadRequestCorrelationId}{endPoint}",
                     errors = new[]
                     {
                             new
@@ -65,14 +65,14 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithPath(urlPattern)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{endPoint}")
                 .UsingPost()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(401)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{endPoint}")
         );
 
     // 403 Forbidden Response
@@ -80,14 +80,14 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithPath(urlPattern)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{endPoint}")
                 .UsingPost()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(403)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{endPoint}")
         );
 
     // 429 Too Many Requests Response
@@ -96,13 +96,13 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Request.Create()
                 .WithPath(urlPattern)
                 .UsingPost()
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{endPoint}")
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(429)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{endPoint}")
                 .WithHeader("Retry-After", "10")
         );
 }

--- a/src/ADDSMock/service-configuration/fss/add-file.cs
+++ b/src/ADDSMock/service-configuration/fss/add-file.cs
@@ -8,7 +8,7 @@ using WireMock.ResponseBuilders;
 public void RegisterFragment(WireMockServer server, MockService mockService)
 {
     var urlPattern = "/batch/(.*)/files/(.*)";
-    var EndPoint = "fss-add-file";
+    var endPoint = "fss-add-file";
 
     // 201 Created Response
     server

--- a/src/ADDSMock/service-configuration/fss/batch-search.cs
+++ b/src/ADDSMock/service-configuration/fss/batch-search.cs
@@ -11,7 +11,7 @@ using System;
 public void RegisterFragment(WireMockServer server, MockService mockService)
 {
     var urlPattern = ".*/batch.*";
-    var EndPoint = "fss-batch-search";
+    var endPoint = "fss-batch-search";
 
     server
         .Given(
@@ -37,28 +37,28 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
          .Given(
              Request.Create()
                 .WithPath(urlPattern)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{endPoint}")
                 .UsingGet()
          )
          .RespondWith(
              Response.Create()
                 .WithStatusCode(401)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{endPoint}")
          );
 
     server
          .Given(
              Request.Create()
                 .WithPath(urlPattern)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{endPoint}")
                 .UsingGet()
          )
          .RespondWith(
              Response.Create()
                 .WithStatusCode(403)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{endPoint}")
          );
 
     server
@@ -66,14 +66,14 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Request.Create()
                 .WithPath(urlPattern)
                 .UsingGet()
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{endPoint}")
          )
          .RespondWith(
              Response.Create()
                 .WithStatusCode(429)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
                 .WithHeader("Retry-After", "10")
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{endPoint}")
          );
 
     server
@@ -81,16 +81,16 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Request.Create()
                 .WithPath(urlPattern)
                 .UsingGet()
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{endPoint}")
          )
          .RespondWith(
              Response.Create()
                 .WithStatusCode(400)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{endPoint}")
                 .WithBodyAsJson(new
                 {
-                    correlationId = $"{MockConstants.BadRequestCorrelationId}{EndPoint}",
+                    correlationId = $"{MockConstants.BadRequestCorrelationId}{endPoint}",
                     errors = new[]
                     {
                             new { source = "Search Product", description = "Bad Request" }

--- a/src/ADDSMock/service-configuration/fss/batch-search.cs
+++ b/src/ADDSMock/service-configuration/fss/batch-search.cs
@@ -22,7 +22,11 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Response.Create()
                 .WithCallback(request =>
                 {
-                    return FSSResponseGenerator.ProvideSearchFilterResponse(request);
+                    var templatePath = mockService.Files
+                        .Where(x => x.Name == "search-product.json")
+                        .Select(x => x.Path)
+                        .FirstOrDefault();
+                    return FSSResponseGenerator.ProvideSearchFilterResponse(request, templatePath);
                 })
         );
 

--- a/src/ADDSMock/service-configuration/fss/create-batch.cs
+++ b/src/ADDSMock/service-configuration/fss/create-batch.cs
@@ -62,11 +62,11 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
                     correlationId = $"{MockConstants.BadRequestCorrelationId}{EndPoint}",
                     errors = new[]
                     {
-                            new
-                            {
-                                source = "Create Batch",
-                                description = "Invalid Expiry Date Format."
-                            }
+                        new
+                        {
+                            source = "Create Batch",
+                            description = "Invalid Expiry Date Format."
+                        }
                     }
                 })
         );

--- a/src/ADDSMock/service-configuration/fss/create-batch.cs
+++ b/src/ADDSMock/service-configuration/fss/create-batch.cs
@@ -8,7 +8,7 @@ using WireMock.ResponseBuilders;
 public void RegisterFragment(WireMockServer server, MockService mockService)
 {
     var urlPattern = ".*/batch";
-    var EndPoint = "fss-create-batch";
+    var endPoint = "fss-create-batch";
 
     // 201 Created Response
     server
@@ -37,7 +37,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Response.Create()
                 .WithStatusCode(201)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.CreatedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.CreatedCorrelationId}{endPoint}")
                 .WithBodyAsJson(new
                 {
                     batchId = Guid.NewGuid().ToString()
@@ -50,16 +50,16 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Request.Create()
                 .WithPath(urlPattern)
                 .UsingPost()
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{endPoint}")
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(400)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{endPoint}")
                 .WithBodyAsJson(new
                 {
-                    correlationId = $"{MockConstants.BadRequestCorrelationId}{EndPoint}",
+                    correlationId = $"{MockConstants.BadRequestCorrelationId}{endPoint}",
                     errors = new[]
                     {
                         new
@@ -77,13 +77,13 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Request.Create()
                 .WithPath(urlPattern)
                 .UsingPost()
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{endPoint}")
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(401)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{endPoint}")
         );
 
     // 403 Forbidden Response
@@ -92,13 +92,13 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Request.Create()
                 .WithPath(urlPattern)
                 .UsingPost()
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{endPoint}")
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(403)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{endPoint}")
         );
 
     // 429 Too Many Requests Response
@@ -107,13 +107,13 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Request.Create()
                 .WithPath(urlPattern)
                 .UsingPost()
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{endPoint}")
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(429)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{endPoint}")
                 .WithHeader("Retry-After", "10")
         );
 }

--- a/src/ADDSMock/service-configuration/fss/file-download.cs
+++ b/src/ADDSMock/service-configuration/fss/file-download.cs
@@ -13,7 +13,7 @@ using System;
 public void RegisterFragment(WireMockServer server, MockService mockService)
 {
     var urlPattern = ".*/batch/(.*)/files/(.*)";
-    var EndPoint = "fss-file-download";
+    var endPoint = "fss-file-download";
 
     // 200 OK Response with File Download
     server
@@ -57,17 +57,17 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithPath(new RegexMatcher(@"/batch/[a-fA-F0-9-]{36}/files/"))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{endPoint}")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(400)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{endPoint}")
                 .WithBodyAsJson(new
                 {
-                    correlationId = $"{MockConstants.BadRequestCorrelationId}{EndPoint}",
+                    correlationId = $"{MockConstants.BadRequestCorrelationId}{endPoint}",
                     errors = new[]
                     {
                             new
@@ -84,14 +84,14 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithPath(new RegexMatcher(urlPattern))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{endPoint}")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(401)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{endPoint}")
         );
 
     // 403 Forbidden Response
@@ -99,14 +99,14 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithPath(new RegexMatcher(urlPattern))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{endPoint}")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(403)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{endPoint}")
         );
 
     // 404 File Not Found Response
@@ -115,13 +115,13 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Request.Create()
                 .WithPath(new RegexMatcher(urlPattern))
                 .UsingGet()
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.FileNotFoundCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.FileNotFoundCorrelationId}{endPoint}")
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(404)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.FileNotFoundCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.FileNotFoundCorrelationId}{endPoint}")
         );
 
     // 410 Gone Response
@@ -130,13 +130,13 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Request.Create()
                 .WithPath(new RegexMatcher(urlPattern))
                 .UsingGet()
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.GoneCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.GoneCorrelationId}{endPoint}")
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(410)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.GoneCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.GoneCorrelationId}{endPoint}")
         );
 
     // 416 Range Not Satisfiable Response
@@ -144,14 +144,14 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithPath(new RegexMatcher(urlPattern))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.RangeNotSatisfiableCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.RangeNotSatisfiableCorrelationId}{endPoint}")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(416)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.RangeNotSatisfiableCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.RangeNotSatisfiableCorrelationId}{endPoint}")
         );
 
     // 429 Too Many Requests Response
@@ -160,14 +160,14 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Request.Create()
                 .WithPath(new RegexMatcher(urlPattern))
                 .UsingGet()
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{endPoint}")
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(429)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
                 .WithHeader("Retry-After", "10")
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TooManyRequestsCorrelationId}{endPoint}")
         );
 
     // 307 Temporary Redirect Response
@@ -176,13 +176,13 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
             Request.Create()
                 .WithPath(new RegexMatcher(urlPattern))
                 .UsingGet()
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TemporaryRedirectCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TemporaryRedirectCorrelationId}{endPoint}")
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(307)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
                 .WithHeader("Redirect-Location", "https://example.com/redirect")
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TemporaryRedirectCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.TemporaryRedirectCorrelationId}{endPoint}")
         );
 }

--- a/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
+++ b/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
@@ -135,7 +135,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.RangeNotSatisfiableCorrelationId}{endPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnsupportedMediaTypeCorrelationId}{endPoint}")
                 .UsingGet()
         )
         .RespondWith(

--- a/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
+++ b/src/ADDSMock/service-configuration/scs/basic-catalogue.cs
@@ -8,7 +8,7 @@ using WireMock.ResponseBuilders;
 public void RegisterFragment(WireMockServer server, MockService mockService)
 {
     var urlPattern = ".*/v2/catalogues/s100/basic.*";
-    var EndPoint = "scs-basic-catalogue";
+    var endPoint = "scs-basic-catalogue";
 
     server
         .Given(
@@ -21,7 +21,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
                 .WithStatusCode(200)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
                 .WithHeader("Last-Modified", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.CreatedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.CreatedCorrelationId}{endPoint}")
                 .WithBodyFromFile(mockService.Files.FirstOrDefault()?.Path)
         );
 
@@ -29,31 +29,31 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.NotModifiedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.NotModifiedCorrelationId}{endPoint}")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(304)
                 .WithHeader("Last-Modified", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.NotModifiedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.NotModifiedCorrelationId}{endPoint}")
         );
 
     server
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{endPoint}")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(400)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.BadRequestCorrelationId}{endPoint}")
                 .WithBodyAsJson(new
                 {
-                    correlationId = $"{MockConstants.BadRequestCorrelationId}{EndPoint}",
+                    correlationId = $"{MockConstants.BadRequestCorrelationId}{endPoint}",
                     errors = new[]
                     {
                         new
@@ -69,17 +69,17 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.InternalServerErrorCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.InternalServerErrorCorrelationId}{endPoint}")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(500)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.InternalServerErrorCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.InternalServerErrorCorrelationId}{endPoint}")
                 .WithBodyAsJson(new
                 {
-                    correlationId = $"{MockConstants.InternalServerErrorCorrelationId}{EndPoint}",
+                    correlationId = $"{MockConstants.InternalServerErrorCorrelationId}{endPoint}",
                     details = "Internal Server Error"
                 })
         );
@@ -88,45 +88,45 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{endPoint}")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(401)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.UnauthorizedCorrelationId}{endPoint}")
         );
 
     server
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{endPoint}")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(403)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.ForbiddenCorrelationId}{endPoint}")
         );
 
     server
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.FileNotFoundCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.FileNotFoundCorrelationId}{endPoint}")
                 .UsingGet()
         )
         .RespondWith(
             Response.Create()
                 .WithStatusCode(404)
                 .WithHeader(MockConstants.ContentTypeHeader, MockConstants.ApplicationJson)
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.FileNotFoundCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.FileNotFoundCorrelationId}{endPoint}")
                 .WithBodyAsJson(new
                 {
-                    correlationId = $"{MockConstants.FileNotFoundCorrelationId}{EndPoint}",
+                    correlationId = $"{MockConstants.FileNotFoundCorrelationId}{endPoint}",
                     details = "Not Found"
                 })
         );
@@ -135,7 +135,7 @@ public void RegisterFragment(WireMockServer server, MockService mockService)
         .Given(
             Request.Create()
                 .WithUrl(new RegexMatcher(urlPattern))
-                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.RangeNotSatisfiableCorrelationId}{EndPoint}")
+                .WithHeader(MockConstants.CorrelationIdHeader, $"{MockConstants.RangeNotSatisfiableCorrelationId}{endPoint}")
                 .UsingGet()
         )
         .RespondWith(


### PR DESCRIPTION
This PR contains changes for refactoring the commonly used correlation ids for error codes to read from MockConstants file also removing the underscore character(_) from the header used for the correlation ID i.e. 'X-Correlation-ID':

**Code Changes:**

1. FSSResponseGenerator.cs
2. MockConstants.cs
3. add-file.cs
4. batch-search.cs
5. create-batch.cs
6. file-download.cs
7. basic-catalogue.cs