### PR TITLE
Add new HTTP status codes and update handling

### DIFF
--- a/src/UKHO.ADDS.Mocks/Configuration/Mocks/fss/CommitBatchEndpoint.cs
+++ b/src/UKHO.ADDS.Mocks/Configuration/Mocks/fss/CommitBatchEndpoint.cs
@@ -30,7 +30,13 @@ namespace UKHO.ADDS.Mocks.Configuration.Mocks.fss
                 switch (state)
                 {
                     case WellKnownState.Default:
-                        var result = new { uri = $"/batch/{batchId}/status" };
+                        var result = new
+                        {
+                            status = new
+                            {
+                                uri = $"/batch/{batchId}/status"
+                            }
+                        };
                         return Results.Accepted("",result);
 
                     case WellKnownState.BadRequest:

--- a/src/UKHO.ADDS.Mocks/Domain/Configuration/ServiceDefinition.cs
+++ b/src/UKHO.ADDS.Mocks/Domain/Configuration/ServiceDefinition.cs
@@ -37,6 +37,11 @@ namespace UKHO.ADDS.Mocks.Domain.Configuration
             _states.Add(new StateDefinition(WellKnownState.UnsupportedMediaType, "Returns Unsupported Media Type (415)"));
             _states.Add(new StateDefinition(WellKnownState.InternalServerError, "Returns Internal Server Error (500)"));
             _states.Add(new StateDefinition(WellKnownState.Unauthorized, "Returns Unauthorized (401)"));
+            _states.Add(new StateDefinition(WellKnownState.TooManyRequests, "Returns Too Many Requests (429)"));
+            _states.Add(new StateDefinition(WellKnownState.TemporaryRedirect, "Returns Temporary Redirect (307)"));
+            _states.Add(new StateDefinition(WellKnownState.Gone, "Returns Gone (410)"));
+            _states.Add(new StateDefinition(WellKnownState.RangeNotSatisfiable, "Returns Range Not Satisfiable (416)"));
+            _states.Add(new StateDefinition(WellKnownState.ImATeapot, "Returns I am a Teapot (418)"));
         }
 
         public string Prefix => _prefix;

--- a/src/UKHO.ADDS.Mocks/Domain/States/DefaultStateHandler.cs
+++ b/src/UKHO.ADDS.Mocks/Domain/States/DefaultStateHandler.cs
@@ -7,15 +7,21 @@ namespace UKHO.ADDS.Mocks.States
         public static IResult HandleWellKnownState(string state) =>
             state switch
             {
+                WellKnownState.TooManyRequests => Results.StatusCode(StatusCodes.Status429TooManyRequests),
+                WellKnownState.TemporaryRedirect => Results.StatusCode(StatusCodes.Status307TemporaryRedirect),
+                WellKnownState.Gone => Results.StatusCode(StatusCodes.Status410Gone),
+                WellKnownState.RangeNotSatisfiable => Results.StatusCode(StatusCodes.Status416RangeNotSatisfiable),
+                WellKnownState.Forbidden => Results.StatusCode(StatusCodes.Status403Forbidden),
+                WellKnownState.UnsupportedMediaType => Results.StatusCode(StatusCodes.Status415UnsupportedMediaType),
+                WellKnownState.NotModified => Results.StatusCode(StatusCodes.Status304NotModified),
+                WellKnownState.Conflict => Results.Conflict("Conflict occurred"),
+                WellKnownState.NotFound => Results.NotFound("Not found"),
                 WellKnownState.BadRequest => Results.BadRequest("Bad request"),
                 WellKnownState.Unauthorized => Results.Unauthorized(),
-                WellKnownState.Forbidden => Results.StatusCode(403),
-                WellKnownState.NotFound => Results.NotFound("Not found"),
-                WellKnownState.NotModified => Results.StatusCode(304),
-                WellKnownState.Conflict => Results.Conflict("Conflict occurred"),
-                WellKnownState.UnsupportedMediaType => Results.StatusCode(415),
-                WellKnownState.InternalServerError => Results.StatusCode(500),
+                WellKnownState.InternalServerError => Results.InternalServerError(),
+                WellKnownState.ImATeapot => Results.StatusCode(StatusCodes.Status418ImATeapot),
                 _ => Results.NotFound("You must handle the default state in your endpoint")
+
             };
     }
 }

--- a/src/UKHO.ADDS.Mocks/Domain/States/WellKnownState.cs
+++ b/src/UKHO.ADDS.Mocks/Domain/States/WellKnownState.cs
@@ -14,5 +14,10 @@ namespace UKHO.ADDS.Mocks.States
         public const string Conflict = "conflict";
         public const string UnsupportedMediaType = "unsupportedmediatype";
         public const string InternalServerError = "internalservererror";
+        public const string TooManyRequests = "toomanyrequests";
+        public const string TemporaryRedirect = "temporaryredirect";
+        public const string Gone = "gone";
+        public const string RangeNotSatisfiable = "rangenotsatisfiable";
+        public const string ImATeapot = "imateapot";
     }
 }


### PR DESCRIPTION
Add new HTTP status codes and update handling

Introduce new HTTP status codes: "Too Many Requests" (429), "Temporary Redirect" (307), "Gone" (410), "Range Not Satisfiable" (416), and "I am a Teapot" (418). Update response structure in `CommitBatchEndpoint.cs` to include a nested `status` object. Enhance state handling in `DefaultStateHandler.cs` and define new constants in `WellKnownState.cs`.