### PR TITLE
Add PayloadTooLarge state handling for HTTP 413

### DIFF
--- a/src/UKHO.ADDS.Mocks/Domain/Configuration/ServiceDefinition.cs
+++ b/src/UKHO.ADDS.Mocks/Domain/Configuration/ServiceDefinition.cs
@@ -41,6 +41,7 @@ namespace UKHO.ADDS.Mocks.Domain.Configuration
             _states.Add(new StateDefinition(WellKnownState.TemporaryRedirect, "Returns Temporary Redirect (307)"));
             _states.Add(new StateDefinition(WellKnownState.Gone, "Returns Gone (410)"));
             _states.Add(new StateDefinition(WellKnownState.RangeNotSatisfiable, "Returns Range Not Satisfiable (416)"));
+            _states.Add(new StateDefinition(WellKnownState.PayloadTooLarge, "Returns Payload Too Large (413)"));
             _states.Add(new StateDefinition(WellKnownState.ImATeapot, "Returns I am a Teapot (418)"));
         }
 

--- a/src/UKHO.ADDS.Mocks/Domain/States/DefaultStateHandler.cs
+++ b/src/UKHO.ADDS.Mocks/Domain/States/DefaultStateHandler.cs
@@ -14,6 +14,7 @@ namespace UKHO.ADDS.Mocks.States
                 WellKnownState.Forbidden => Results.StatusCode(StatusCodes.Status403Forbidden),
                 WellKnownState.UnsupportedMediaType => Results.StatusCode(StatusCodes.Status415UnsupportedMediaType),
                 WellKnownState.NotModified => Results.StatusCode(StatusCodes.Status304NotModified),
+                WellKnownState.PayloadTooLarge => Results.StatusCode(StatusCodes.Status413PayloadTooLarge),
                 WellKnownState.Conflict => Results.Conflict("Conflict occurred"),
                 WellKnownState.NotFound => Results.NotFound("Not found"),
                 WellKnownState.BadRequest => Results.BadRequest("Bad request"),

--- a/src/UKHO.ADDS.Mocks/Domain/States/WellKnownState.cs
+++ b/src/UKHO.ADDS.Mocks/Domain/States/WellKnownState.cs
@@ -18,6 +18,7 @@ namespace UKHO.ADDS.Mocks.States
         public const string TemporaryRedirect = "temporaryredirect";
         public const string Gone = "gone";
         public const string RangeNotSatisfiable = "rangenotsatisfiable";
+        public const string PayloadTooLarge = "payloadtoolarge";
         public const string ImATeapot = "imateapot";
     }
 }


### PR DESCRIPTION
Add PayloadTooLarge state handling for HTTP 413

Introduces a new state, `PayloadTooLarge`, to the `StateDefinition` in `ServiceDefinition.cs`. Updates `DefaultStateHandler.cs` to handle this state by returning the appropriate HTTP status code (413). Adds a constant for `PayloadTooLarge` in `WellKnownState.cs` for consistent referencing throughout the application.