### PR TITLE
Refactor endpoint handling for z_adds_mat_info httpGet to httpPost

### DIFF
--- a/src/UKHO.ADDS.Mocks/Configuration/Mocks/sap/PostZAddsMatInfoEndpoint.cs
+++ b/src/UKHO.ADDS.Mocks/Configuration/Mocks/sap/PostZAddsMatInfoEndpoint.cs
@@ -3,10 +3,10 @@ using UKHO.ADDS.Mocks.States;
 
 namespace UKHO.ADDS.Mocks.Configuration.Mocks.sap
 {
-    public class GetZAddsMatInfoEndpoint : ServiceEndpointMock
+    public class PostZAddsMatInfoEndpoint : ServiceEndpointMock
     {
         public override void RegisterSingleEndpoint(IEndpointMock endpoint) =>
-            endpoint.MapGet("/z_adds_mat_info.asmx", (HttpRequest request) =>
+            endpoint.MapPost("/z_adds_mat_info.asmx", (HttpRequest request) =>
             {
                 var state = GetState(request);
 


### PR DESCRIPTION
Refactor endpoint handling for z_adds_mat_info

Removed GetZAddsMatInfoEndpoint class and added
PostZAddsMatInfoEndpoint class to handle POST requests to the /z_adds_mat_info.asmx endpoint. The new class maintains similar state processing logic as the removed class for consistent response handling.