### PR TITLE
Fixed wwwroot paths in App.razor

### DIFF
--- a/src/UKHO.ADDS.Mocks/Dashboard/App.razor
+++ b/src/UKHO.ADDS.Mocks/Dashboard/App.razor
@@ -19,7 +19,7 @@
         frame-src www.youtube.com platform.twitter.com platform.linkedin.com www.linkedin.com;
         upgrade-insecure-requests;"> *@
     <base href="/"/>
-    <link href="css/site.css" rel="stylesheet"/>
+    <link href="_content/UKHO.ADDS.Mocks/css/site.css" rel="stylesheet" />
     <HeadOutlet @rendermode="InteractiveServer"/>
     <RadzenTheme Theme="material3-dark" @rendermode="InteractiveServer"/>
     <link rel="stylesheet" data-name="vs/editor/editor.main" href="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.34.1/min/vs/editor/editor.main.min.css">
@@ -44,7 +44,7 @@
 </div>
 
 <script src="_framework/blazor.web.js"></script>
-<script async src="js/highlight.pack.js"></script>
+    <script async src="_content/UKHO.ADDS.Mocks/js/highlight.pack.js"></script>
 <script src="_content/Radzen.Blazor/Radzen.Blazor.min.js?v=@(typeof(Colors).Assembly.GetName().Version)"></script>
 <script defer data-domain="blazor.radzen.com" src="https://analytics.radzen.com/js/plausible.js"></script>
 <script>var require = { paths: { 'vs': 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.34.1/min/vs' } }</script>
@@ -67,6 +67,6 @@
             navigator.clipboard.writeText(text);
         }
 </script>
-    <script src="js/download.js"></script>
+    <script src="_content/UKHO.ADDS.Mocks/js/download.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This pull request updates the paths of static assets in the `App.razor` file to correctly reference their locations within the `_content/UKHO.ADDS.Mocks/` directory. This ensures compatibility with the hosting environment and proper loading of resources.

### Static asset path updates:

* Updated the path for the `site.css` stylesheet to `_content/UKHO.ADDS.Mocks/css/site.css`.
* Updated the path for the `highlight.pack.js` script to `_content/UKHO.ADDS.Mocks/js/highlight.pack.js`.
* Updated the path for the `download.js` script to `_content/UKHO.ADDS.Mocks/js/download.js`.