### PR TITLE
Added StateScope to test client

### DIFF
--- a/src/UKHO.ADDS.Mocks.Client/StateScope.cs
+++ b/src/UKHO.ADDS.Mocks.Client/StateScope.cs
@@ -1,0 +1,60 @@
+﻿namespace UKHO.ADDS.Mocks.Client
+{
+    public class StateScope : IAsyncDisposable
+    {
+        private readonly MockHttpClientFactory _clientFactory;
+        private readonly string _session;
+
+        private bool _disposed;
+
+        public StateScope(MockHttpClientFactory clientFactory)
+        {
+            _clientFactory = clientFactory;
+            _disposed = false;
+
+            _session = Guid.NewGuid().ToString("N");
+        }
+
+        public async Task SetState(string servicePrefix, string endpointName, string state)
+        {
+            var client = _clientFactory.CreateClient();
+
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(StateScope));
+            }
+
+            try
+            {
+                var response = await client.PostAsync($"/states/endpoints/{_session}/{servicePrefix}/{endpointName}/{state}", null);
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception ex)
+            {
+                await Console.Error.WriteLineAsync($"SetState failed: {ex.Message}");
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            var client = _clientFactory.CreateClient();
+
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            try
+            {
+                var response = await client.DeleteAsync($"/states/endpoints/{_session}");
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception ex)
+            {
+                await Console.Error.WriteLineAsync($"DisposeAsync failed to reset state: {ex.Message}");
+            }
+        }
+    }
+}

--- a/src/UnitTestExamples/StateExamples.cs
+++ b/src/UnitTestExamples/StateExamples.cs
@@ -25,6 +25,21 @@ namespace UnitTestExamples
             Assert.True(response.StatusCode == HttpStatusCode.OK);
         }
 
+        public async Task SetStatePerTest()
+        {
+            // Note - scope is in a using block to ensure it is disposed of after the test, so that the state is reset
+            await using var scope = new StateScope(_factory);
+
+            await scope.SetState("sample", "GetFilesEndpoint", WellKnownState.BadRequest);
+
+            var client = _factory.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, MockUri);
+            var response = await client.SendAsync(request);
+
+            Assert.True(response.StatusCode == HttpStatusCode.BadRequest);
+        }
+
         public async Task SetMockToUnauthorisedState()
         {
             var client = _factory.CreateClient();


### PR DESCRIPTION
This pull request introduces a new class, `StateScope`, to manage the lifecycle of mock HTTP client states, along with a new test method that utilizes this class for state management. The changes improve the handling of mock states and ensure proper cleanup after tests.

### New functionality for state management:

* [`src/UKHO.ADDS.Mocks.Client/StateScope.cs`](diffhunk://#diff-fedf477a0fb0aa3ce2e5dfa3ddfec9fb4c3fc154636d432921950cbe0220e967R1-R60): Added the `StateScope` class, which implements `IAsyncDisposable` to manage mock HTTP client states. It includes methods to set states (`SetState`) and dispose of them asynchronously (`DisposeAsync`). This ensures that states are properly reset after usage.

### Test method enhancement:

* [`src/UnitTestExamples/StateExamples.cs`](diffhunk://#diff-19d1947e3ae27c1bf1a344ee8a57e9b8d232460d86e10646d6ff87215e44895dR28-R42): Added the `SetStatePerTest` method, which uses the new `StateScope` class within a `using` block to set a specific state (`BadRequest`) for the mock HTTP client and verify the response. This ensures state isolation and cleanup after each test.