### PR TITLE
Bump to Aspire 9.4

### DIFF
--- a/src/UKHO.ADDS.Mocks.Client/UKHO.ADDS.Mocks.Client.csproj
+++ b/src/UKHO.ADDS.Mocks.Client/UKHO.ADDS.Mocks.Client.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
   </ItemGroup>
 
 </Project>

--- a/src/UKHO.ADDS.Mocks.LocalHost/UKHO.ADDS.Mocks.LocalHost.csproj
+++ b/src/UKHO.ADDS.Mocks.LocalHost/UKHO.ADDS.Mocks.LocalHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.4.0" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/UKHO.ADDS.Mocks.SampleService/UKHO.ADDS.Mocks.SampleService.csproj
+++ b/src/UKHO.ADDS.Mocks.SampleService/UKHO.ADDS.Mocks.SampleService.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UKHO.ADDS.Mocks/UKHO.ADDS.Mocks.csproj
+++ b/src/UKHO.ADDS.Mocks/UKHO.ADDS.Mocks.csproj
@@ -42,13 +42,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
-    <PackageReference Include="Radzen.Blazor" Version="7.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+    <PackageReference Include="Radzen.Blazor" Version="7.1.7" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.5.3" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.6.8" />
     <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.0.14" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.0.15" />
     <PackageReference Include="UKHO.ADDS.Infrastructure.Results" Version="0.0.50322-alpha.2" />
     <PackageReference Include="UKHO.ADDS.Infrastructure.Serialization" Version="0.0.50322-alpha.2" />
 
@@ -58,7 +58,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.36" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="6.0.36" />
-    <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.7.0" />
     <PackageReference Include="MetadataReferenceService.BlazorWasm" Version="*" />
     <PackageReference Include="Zio" Version="0.21.0" />
 

--- a/src/UnitTestExamples/UnitTestExamples.csproj
+++ b/src/UnitTestExamples/UnitTestExamples.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/UKHO.ADDS.Mocks.Tests/UKHO.ADDS.Mocks.Tests.csproj
+++ b/tests/UKHO.ADDS.Mocks.Tests/UKHO.ADDS.Mocks.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
#### PR Classification
Update project files to reference newer versions of NuGet packages and SDKs.

#### PR Summary
This pull request updates several project files to use the latest versions of various dependencies and SDKs, ensuring compatibility and access to new features. 
- `UKHO.ADDS.Mocks.csproj`: Updated `Microsoft.AspNetCore.OpenApi` to `9.0.8`, `Radzen.Blazor` to `7.1.7`, `Scalar.AspNetCore` to `2.6.8`, `System.IO.Abstractions` to `22.0.15`, and `Microsoft.Extensions.Telemetry.Abstractions` to `9.7.0`.
- `UKHO.ADDS.Mocks.LocalHost.csproj`: Updated `Aspire.AppHost.Sdk` to `9.4.0` and `Aspire.Hosting.AppHost` to `9.4.0`.
- `UKHO.ADDS.Mocks.SampleService.csproj`: Updated `Microsoft.AspNetCore.OpenApi` to `9.0.8`.
- `UnitTestExamples.csproj` and `UKHO.ADDS.Mocks.Tests.csproj`: Updated `xunit.runner.visualstudio` to `3.1.3`. 
- `UKHO.ADDS.Mocks.Client.csproj`: Updated `Microsoft.Extensions.Http` to `9.0.8`.
