### PR TITLE
Package updates

### DIFF
--- a/src/UKHO.ADDS.Mocks.LocalHost/UKHO.ADDS.Mocks.LocalHost.csproj
+++ b/src/UKHO.ADDS.Mocks.LocalHost/UKHO.ADDS.Mocks.LocalHost.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/UKHO.ADDS.Mocks/UKHO.ADDS.Mocks.csproj
+++ b/src/UKHO.ADDS.Mocks/UKHO.ADDS.Mocks.csproj
@@ -43,14 +43,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
-    <PackageReference Include="Radzen.Blazor" Version="7.1.7" />
+    <PackageReference Include="Radzen.Blazor" Version="7.1.8" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.6.8" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.6.9" />
     <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageReference Include="System.IO.Abstractions" Version="22.0.15" />
-    <PackageReference Include="UKHO.ADDS.Infrastructure.Results" Version="0.0.50322-alpha.2" />
-    <PackageReference Include="UKHO.ADDS.Infrastructure.Serialization" Version="0.0.50322-alpha.2" />
+    <PackageReference Include="UKHO.ADDS.Infrastructure.Results" Version="0.0.50327-alpha.2" />
+    <PackageReference Include="UKHO.ADDS.Infrastructure.Serialization" Version="0.0.50327-alpha.2" />
 
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.*-*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.*-*" PrivateAssets="all" />
@@ -58,7 +58,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.36" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="6.0.36" />
-    <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.8.0" />
     <PackageReference Include="MetadataReferenceService.BlazorWasm" Version="*" />
     <PackageReference Include="Zio" Version="0.21.0" />
 


### PR DESCRIPTION
#### PR Classification
Package version updates to improve functionality and compatibility.

#### PR Summary
This pull request updates several package versions to their latest releases for improved performance and stability. 
- `UKHO.ADDS.Mocks.LocalHost.csproj`: Updated `Aspire.Hosting.AppHost` from `9.4.0` to `9.4.1`.
- `UKHO.ADDS.Mocks.csproj`: Updated `Radzen.Blazor` from `7.1.7` to `7.1.8`.
- `UKHO.ADDS.Mocks.csproj`: Updated `Scalar.AspNetCore` from `2.6.8` to `2.6.9`.
- `UKHO.ADDS.Mocks.csproj`: Updated `UKHO.ADDS.Infrastructure.Results` from `0.0.50322-alpha.2` to `0.0.50327-alpha.2`.
- `UKHO.ADDS.Mocks.csproj`: Updated `Microsoft.Extensions.Telemetry.Abstractions` from `9.7.0` to `9.8.0`.
