### PR TITLE
Package updates

### DIFF
--- a/src/UKHO.ADDS.Mocks.Client/UKHO.ADDS.Mocks.Client.csproj
+++ b/src/UKHO.ADDS.Mocks.Client/UKHO.ADDS.Mocks.Client.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/UKHO.ADDS.Mocks.SampleService/UKHO.ADDS.Mocks.SampleService.csproj
+++ b/src/UKHO.ADDS.Mocks.SampleService/UKHO.ADDS.Mocks.SampleService.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UKHO.ADDS.Mocks/UKHO.ADDS.Mocks.csproj
+++ b/src/UKHO.ADDS.Mocks/UKHO.ADDS.Mocks.csproj
@@ -42,13 +42,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
-    <PackageReference Include="Radzen.Blazor" Version="7.3.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
+    <PackageReference Include="Radzen.Blazor" Version="7.3.5" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.7.2" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.8.5" />
     <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="22.0.15" />
+    <PackageReference Include="System.IO.Abstractions" Version="22.0.16" />
     <PackageReference Include="UKHO.ADDS.Infrastructure.Results" Version="0.0.50327-alpha.2" />
     <PackageReference Include="UKHO.ADDS.Infrastructure.Serialization" Version="0.0.50327-alpha.2" />
 
@@ -58,9 +58,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.36" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="6.0.36" />
-    <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.9.0" />
     <PackageReference Include="MetadataReferenceService.BlazorWasm" Version="*" />
-    <PackageReference Include="Zio" Version="0.21.0" />
+    <PackageReference Include="Zio" Version="0.21.2" />
 
   </ItemGroup>
 


### PR DESCRIPTION
Package updates

#### PR Classification
Dependency updates to ensure compatibility and address potential improvements or fixes.

#### PR Summary
This pull request updates several NuGet package dependencies across multiple projects to their latest versions for improved stability and functionality.  
- **`UKHO.ADDS.Mocks.Client.csproj`**: Updated `Microsoft.Extensions.Http` to version `9.0.9`.  
- **`UKHO.ADDS.Mocks.SampleService.csproj`**: Updated `Microsoft.AspNetCore.OpenApi` to version `9.0.9`.  
- **`UKHO.ADDS.Mocks.csproj`**: Updated `Microsoft.AspNetCore.OpenApi`, `Radzen.Blazor`, `Scalar.AspNetCore`, `System.IO.Abstractions`, `Microsoft.Extensions.Telemetry.Abstractions`, and `Zio` to their latest versions.  
